### PR TITLE
Fixed QR Codes containing the protocol twice

### DIFF
--- a/src/app/EventParticipant.php
+++ b/src/app/EventParticipant.php
@@ -132,7 +132,11 @@ class EventParticipant extends Model
      */
     public function generateQRCode()
     {
-        $ticketUrl = 'https://' . config('app.url') . '/tickets/retrieve/' . $this->id;
+        if(Str::startsWith(config('app.url'), ['http://', 'https://'])) {
+            $ticketUrl = config('app.url') . '/tickets/retrieve/' . $this->id;
+        } else {
+            $ticketUrl = 'https://' . config('app.url') . '/tickets/retrieve/' . $this->id;
+        }
         $qrCodePath = 'storage/images/events/' . $this->event->slug . '/qr/';
         $qrCodeFileName =  $this->event->slug . '-' . Str::random(32) . '.png';
         if (!file_exists($qrCodePath)) {


### PR DESCRIPTION
Previously generated QR codes would contain the protocol (http:// or https://) twice since it could already be contained in the APP_URL environment variable.
I added a check to only add the protocol if it's not present in the target URL.