### PR TITLE
Events page: Space between sold/totalt tickets

### DIFF
--- a/src/resources/views/events/show.blade.php
+++ b/src/resources/views/events/show.blade.php
@@ -54,7 +54,7 @@
 		<div class="row">
 			<div class="col-12">
 				<h3>
-					<strong>{{ max($event->capacity - $event->eventParticipants->count(), 0) }}/{{ $event->capacity }}</strong>@lang('events.ticketsavailable')
+					<strong>{{ max($event->capacity - $event->eventParticipants->count(), 0) }}/{{ $event->capacity }}</strong> @lang('events.ticketsavailable')
 				</h3>
 			</div>
 			@if ($event->capacity > 0)


### PR DESCRIPTION
I added a space between sold/totalt tickets that was missing. So only formatting has changed. 