### PR TITLE
Timetable improvements

### DIFF
--- a/src/app/Http/Controllers/Admin/Events/TimetableDataController.php
+++ b/src/app/Http/Controllers/Admin/Events/TimetableDataController.php
@@ -86,4 +86,23 @@ class TimetableDataController extends Controller
         Session::flash('alert-success', 'Successfully updated Timetable Slot!');
         return Redirect::back();
     }
+
+    /**
+     * Destroy Timetable Data
+     * @param  Event              $event
+     * @param  EventTimetable     $timetable
+     * @param  EventTimetableData $data
+     */
+    public function destroy(Event $event, EventTimetable $timetable, EventTimetableData $data)
+    {
+        try {
+            $data->delete();
+            Session::flash('alert-success', 'Successfully deleted Timetable Slot!');
+        } catch (\Exception $e) {
+            // Log the exception message
+            \Log::error('Error deleting Timetable Slot: ' . $e->getMessage());
+            Session::flash('alert-danger', 'Cannot delete Timetable Slot!');
+        }
+        return Redirect::back();
+    }
 }

--- a/src/app/Http/Controllers/Admin/Events/TimetablesController.php
+++ b/src/app/Http/Controllers/Admin/Events/TimetablesController.php
@@ -47,6 +47,7 @@ class TimetablesController extends Controller
      */
     public function show(Event $event, EventTimetable $timetable)
     {
+        $timetable->data = $timetable->data->sortBy('start_time');
         return view('admin.events.timetables.show')
             ->withEvent($event)
             ->withTimetable($timetable);

--- a/src/app/Http/routes.php
+++ b/src/app/Http/routes.php
@@ -340,6 +340,8 @@ Route::group(['middleware' => ['installed']], function () {
                 '/admin/events/{event}/timetables/{timetable}/data/{data}',
                 'Admin\Events\TimetableDataController@update'
             );
+            Route::delete('/admin/events/{event}/timetables/{timetable}/data/{data}', 'Admin\Events\TimetableDataController@destroy');
+
 
             /**
              * Tournaments

--- a/src/lang/de/events.php
+++ b/src/lang/de/events.php
@@ -77,6 +77,9 @@ return [
     'buy' => 'Kaufen',
     'noseatableticket' => 'Kein Ticket mit Sitzplatz in Besitz',
     'noseatableticketlist' => 'Kein Ticket mit Sitzplatz in Besitz',
+    'timetable-primary-pill' => 'Hauptzeitplan',
+    'timetable-created-at' => 'Erstellt:',
+    'timetable-updated-at' => 'Aktualisiert:',
     /* Big */
     'plssignin' => 'Bitte melden Sie sich auf der Hauptseite an',
     /* Tournaments show*/

--- a/src/lang/en/events.php
+++ b/src/lang/en/events.php
@@ -77,6 +77,9 @@ return [
     'buy' => 'Buy',
     'noseatableticket' => 'You own no seatable ticket.',
     'noseatableticketlist' => 'No seatable Ticket owned.',
+    'timetable-primary-pill' => 'Primary Timetable',
+    'timetable-created-at' => 'Created At:',
+    'timetable-updated-at' => 'updated At:',
     /* Big */
     'plssignin' => 'Please sign in at the main desk',
     /* Tournaments show*/

--- a/src/resources/views/admin/events/timetables/show.blade.php
+++ b/src/resources/views/admin/events/timetables/show.blade.php
@@ -57,6 +57,12 @@
 								<td width="10%">
 									<button type="button" class="btn btn-primary btn-sm btn-block" data-toggle="modal" onclick="editTimeSlot('{{ $slot->id }}', '{{ $slot->start_time }}', '{{ $slot->name }}', '{{ $slot->desc }}')" data-target="#editTimeSlotModal">Edit</button>
 								</td>
+								<td>
+								{{ Form::open(array('url'=>'/admin/events/' . $event->slug . '/timetables/' . $timetable->slug . '/data/' . $slot->id, 'onsubmit' => 'return ConfirmDelete()')) }}
+								{{ Form::hidden('_method', 'DELETE') }}
+								<button type="submit" class="btn btn-danger btn-sm btn-block">Delete</button>
+								{{ Form::close() }}
+								</td>
 							</tr>
 						@endforeach
 					</tbody>

--- a/src/resources/views/events/show.blade.php
+++ b/src/resources/views/events/show.blade.php
@@ -435,7 +435,22 @@
 	@if (strtoupper($timetable->status) == 'DRAFT')
 	<h4>DRAFT</h4>
 	@endif
-	<h4>{{ $timetable->name }}</h4>
+	@if ($timetable->primary == '1')
+    <div class="d-flex align-items-center">
+        <h4 class="mb-1">{{ $timetable->name }} </h4>
+        <span class="badge bg-primary ms-3">@lang('events.timetable-primary-pill')</span>
+    </div>
+@else
+    <h4>{{ $timetable->name }}</h4>
+@endif
+	
+	<p>
+    @lang('events.timetable-created-at')
+    {{ $timetable->created_at->toDateString() == now()->toDateString() ? $timetable->created_at->format('M d, H:i') : ($timetable->created_at->year == now()->year ? $timetable->created_at->format('M d') : $timetable->created_at->format('M d, Y')) }}, 
+    @lang('events.timetable-updated-at')
+    {{ $timetable->updated_at->toDateString() == now()->toDateString() ? $timetable->updated_at->format('M d, H:i') : ($timetable->updated_at->year == now()->year ? $timetable->updated_at->format('M d') : $timetable->updated_at->format('M d, Y')) }}
+	</p>
+
 	<table class="table table-striped">
 		<thead>
 			<th>

--- a/src/resources/views/events/show.blade.php
+++ b/src/resources/views/events/show.blade.php
@@ -431,7 +431,7 @@
 		<a name="timetable"></a>
 		<h3><i class="fas fa-calendar-alt mr-3"></i>@lang('events.timetable')</h3>
 	</div>
-	@foreach ($event->timetables as $timetable)
+	@foreach ($event->timetables->sortByDesc('primary') as $timetable)
 	@if (strtoupper($timetable->status) == 'DRAFT')
 	<h4>DRAFT</h4>
 	@endif


### PR DESCRIPTION
I takled the improvement of the timetable management and presentation solving: #525

Admins now can delete Time Table Slot:
![image](https://github.com/Lan2Play/eventula-manager/assets/17619897/258b8af0-4cf2-427c-a65c-1b40cfd212c7)

The Slots are now in the correct order, based on the start_time entry and if a timetable is marked as primary it shows a bootstrap pill next to the name:
![image](https://github.com/Lan2Play/eventula-manager/assets/17619897/1ad8474a-e8f3-4a85-beb0-12d2b67801c3)

Time Tables are now displayed at the top, if marked as primary:
![image](https://github.com/Lan2Play/eventula-manager/assets/17619897/0c7b73c6-be18-46f3-b4f6-268cb3d4d852)

If mulitple Timetables are markes as Primary, the order is default (ID)
![image](https://github.com/Lan2Play/eventula-manager/assets/17619897/d4121892-21d5-4a3e-a457-bf3a8affd0bb)
