### PR TITLE
Create duplicate of seating plan

### DIFF
--- a/src/app/Http/Controllers/Admin/Events/SeatingController.php
+++ b/src/app/Http/Controllers/Admin/Events/SeatingController.php
@@ -235,6 +235,13 @@ class SeatingController extends Controller
         $plan = EventSeatingPlan::where('id', $request->get('duplicate'))->first();
         $dupe = $plan->replicate();
         $dupe->status = 'DRAFT';
+        $dupe->slug = null;
+        if ($request->has('name_override')) {
+            $dupe->name = $request->get('name_override');
+        }
+        if ($request->has('short_name_override')) {
+            $dupe->name_short = $request->get('short_name_override');
+        }
         if ($dupe->image_path) {
             $imageName = basename($dupe->image_path);
             $imagePath = "public/images/events/{$event->slug}/seating/{$dupe->slug}/{$imageName}";

--- a/src/app/Http/Controllers/Admin/Events/SeatingController.php
+++ b/src/app/Http/Controllers/Admin/Events/SeatingController.php
@@ -72,7 +72,7 @@ class SeatingController extends Controller
      * @return RedirectResponse
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function create(Event $event, Request $request)
+    protected function create(Event $event, Request $request)
     {
         $rules = [
             "name"      => "required",

--- a/src/app/Http/Controllers/Admin/Events/SeatingController.php
+++ b/src/app/Http/Controllers/Admin/Events/SeatingController.php
@@ -236,10 +236,16 @@ class SeatingController extends Controller
         $dupe = $plan->replicate();
         $dupe->status = 'DRAFT';
         if ($dupe->image_path) {
-            Storage::copy(
-                $dupe->image_path,
-                "public/images/events/{$event->slug}/seating/"
-            );
+            $imageName = basename($dupe->image_path);
+            $imagePath = "public/images/events/{$event->slug}/seating/{$dupe->slug}/{$imageName}";
+            if (Storage::copy(
+                str_replace('/storage/', 'public/', $dupe->image_path),
+                $imagePath
+            )) {
+                $dupe->image_path = str_replace('public/', '/storage/', $imagePath);
+            } else {
+                $dupe->image_path = null;
+            }
         }
         dd($plan, $dupe);
         Session::flash('alert-success', 'Successfully duplicated seating plan');

--- a/src/app/Http/Controllers/Admin/Events/SeatingController.php
+++ b/src/app/Http/Controllers/Admin/Events/SeatingController.php
@@ -243,6 +243,7 @@ class SeatingController extends Controller
         // Copy seating plan
         $dupe = $plan->replicate();
         $dupe->status = 'DRAFT';
+        $dupe->event_id = $event->id;
         unset($dupe->slug);
 
         if ($request->filled('name_override')) {

--- a/src/app/Http/Controllers/Admin/Events/SeatingController.php
+++ b/src/app/Http/Controllers/Admin/Events/SeatingController.php
@@ -247,8 +247,11 @@ class SeatingController extends Controller
                 $dupe->image_path = null;
             }
         }
-        dd($plan, $dupe);
-        Session::flash('alert-success', 'Successfully duplicated seating plan');
+        if ($dupe->save()) {
+            Session::flash('alert-success', 'Successfully duplicated seating plan');
+        } else {
+            Session::flash('alert-danger', 'Seating plan could not be copied');
+        }
         return Redirect::back();
     }
 

--- a/src/app/Libraries/Helpers.php
+++ b/src/app/Libraries/Helpers.php
@@ -2,6 +2,8 @@
 
 namespace App\Libraries;
 
+use App\Event;
+use App\EventSeatingPlan;
 use Session;
 use Illuminate\Http\Request;
 use Exception;
@@ -969,5 +971,15 @@ class Helpers
     public static function getSeoCustomDescription($description)
     {
         return $description. Helpers::getPoweredByLine();
+    }
+
+    public static function getExistingSeatingPlansSelect() {
+        $result = [];
+        foreach(EventSeatingPlan::all(['id', 'name', 'event_id']) as $plan) {
+            $event = Event::where('id', $plan->event_id)->first();
+            $result[$event->display_name] ??= [];
+            $result[$event->display_name][$plan->id] = $plan->name;
+        }
+        return $result;
     }
 }

--- a/src/resources/views/admin/events/seating/index.blade.php
+++ b/src/resources/views/admin/events/seating/index.blade.php
@@ -114,19 +114,27 @@
 			</div>
 			<div class="card-body">
 				{{ Form::open(['url' => "/admin/events/{$event->slug}/seating"]) }}
-				<div class="row">
-					<div class="col-12 mb-3">
-						{{ Form::label('duplicate', 'Copy from') }}
-						{{ Form::select(
-    							'duplicate',
-    							Helpers::getExistingSeatingPlansSelect(),
-    							'',
-    							[
-                                    'id' => 'duplicate',
-                                    'class'=> 'form-control'
-								]
-						) }}
-					</div>
+				<div class="mb-3">
+					{{ Form::label('duplicate', 'Copy from') }}
+					{{ Form::select(
+							'duplicate',
+							Helpers::getExistingSeatingPlansSelect(),
+							'',
+							[
+								'id' => 'duplicate',
+								'class'=> 'form-control'
+							]
+					) }}
+				</div>
+				<div class="mb-3">
+					{{ Form::label('name-override', 'Name override') }}
+					{{ Form::text('name_override', null, ['id' => 'name-override', 'class' => 'form-control']) }}
+					<div class="form-text">Name for copy. Leave empty to copy original name</div>
+				</div>
+				<div class="mb-3">
+					{{ Form::label('short-name-override', 'Short name override') }}
+					{{ Form::text('short_name_override', null, ['id' => 'short-name-override', 'class' => 'form-control']) }}
+					<div class="form-text">Short name for copy. Leave empty to copy original short name</div>
 				</div>
 				<button type="submit" class="btn btn-success btn-block">Submit</button>
 				{{ Form::close() }}

--- a/src/resources/views/admin/events/seating/index.blade.php
+++ b/src/resources/views/admin/events/seating/index.blade.php
@@ -108,6 +108,30 @@
 			</div>
 		</div>
 
+		<div class="card mb-3">
+			<div class="card-header">
+				<i class="fa fa-copy fa-fw"></i>Duplicate existing seating plan
+			</div>
+			<div class="card-body">
+				{{ Form::open(['url' => "/admin/events/{$event->slug}/seating"]) }}
+				<div class="row">
+					<div class="col-12 mb-3">
+						{{ Form::label('duplicate', 'Copy from') }}
+						{{ Form::select(
+    							'duplicate',
+    							Helpers::getExistingSeatingPlansSelect(),
+    							'',
+    							[
+                                    'id' => 'duplicate',
+                                    'class'=> 'form-control'
+								]
+						) }}
+					</div>
+				</div>
+				<button type="submit" class="btn btn-success btn-block">Submit</button>
+				{{ Form::close() }}
+			</div>
+		</div>
 	</div>
 </div>
 


### PR DESCRIPTION
## Feature description

This adds a feature to copy an existing seating plan to the current event, instead of creating a seating plan from scratch.

## Motivation

This is a quality-of-life improvement. If the seating plan for a venue hasn't changed from an earlier event, it is more convenient to just copy the seating plan than to create a new one. This is especially true if the seating plan has a bunch of deactivated seats due to the layout, which would be tedious to set inactive all over again.

