### PR TITLE
Revoke or delete EventParticipants and Purchases

### DIFF
--- a/src/app/Event.php
+++ b/src/app/Event.php
@@ -90,6 +90,10 @@ class Event extends Model
      */
     public function eventParticipants()
     {
+        return $this->hasMany('App\EventParticipant')->where('revoked', '=', 0);
+    }
+    public function allEventParticipants()
+    {
         return $this->hasMany('App\EventParticipant');
     }
     public function timetables()

--- a/src/app/EventParticipant.php
+++ b/src/app/EventParticipant.php
@@ -246,4 +246,17 @@ class EventParticipant extends Model
 
         return $pdf->output();
     }
+
+    function setRevoked()
+    {
+        $this->revoked = true;
+        if (!$this->seat) {
+            return $this->save();
+        }
+        if (!$this->seat->delete()) {
+            $this->revoked = false;
+            return false;
+        }
+        return $this->save();
+    }
 }

--- a/src/app/Http/Controllers/Admin/Events/ParticipantsController.php
+++ b/src/app/Http/Controllers/Admin/Events/ParticipantsController.php
@@ -27,7 +27,7 @@ class ParticipantsController extends Controller
     {
         return view('admin.events.participants.index')
             ->withEvent($event)
-            ->withParticipants($event->eventParticipants()->paginate(20));
+            ->withParticipants($event->allEventParticipants()->paginate(20));
     }
 
     /**

--- a/src/app/Http/Controllers/Admin/Events/ParticipantsController.php
+++ b/src/app/Http/Controllers/Admin/Events/ParticipantsController.php
@@ -120,9 +120,14 @@ class ParticipantsController extends Controller
         return Redirect::to('admin/events/' . $event->slug . '/participants/');
     }
 
-
-    
-
-
+    function revoke(Event $event, EventParticipant $participant)
+    {
+        if (!$participant->setRevoked()) {
+            Session::flash('alert-danger', 'Cannot revoke Participant!');
+            return Redirect::to('admin/events/' . $event->slug . '/participants/' . $participant->id);
+        }
+        Session::flash('alert-success', 'Participant has been revoked');
+        return Redirect::to('admin/events/' . $event->slug . '/participants/');
+    }
 
 }

--- a/src/app/Http/Controllers/Admin/Events/ParticipantsController.php
+++ b/src/app/Http/Controllers/Admin/Events/ParticipantsController.php
@@ -130,4 +130,14 @@ class ParticipantsController extends Controller
         return Redirect::to('admin/events/' . $event->slug . '/participants/');
     }
 
+    function delete(Event $event, EventParticipant $participant)
+    {
+        if (!$participant->delete()) {
+            Session::flash('alert-danger', 'Cannot delete participant');
+            return Redirect::to('admin/events/' . $event->slug . '/participants/' . $participant->id);
+        }
+        Session::flash('alert-success', 'Participants deleted');
+        return Redirect::to('admin/events/' . $event->slug . '/participants/');
+    }
+
 }

--- a/src/app/Http/Controllers/Admin/PurchasesController.php
+++ b/src/app/Http/Controllers/Admin/PurchasesController.php
@@ -84,4 +84,14 @@ class PurchasesController extends Controller
         Session::flash('alert-success', 'Successfully updated purchase status!');
         return Redirect::to('/admin/purchases/' . $purchase->id);
     }
+
+    function delete(Purchase $purchase)
+    {
+        if (!$purchase->delete()) {
+            Session::flash('alert-danger', 'Cannot delete Purchase');
+            return Redirect::to('admin/purchases/' . $purchase->id);
+        }
+        Session::flash('alert-success', 'Purchase deleted');
+        return Redirect::to('admin/purchases');
+    }
 }

--- a/src/app/Http/routes.php
+++ b/src/app/Http/routes.php
@@ -691,6 +691,9 @@ Route::group(['middleware' => ['installed']], function () {
             Route::get('/admin/purchases/event', 'Admin\PurchasesController@showEvent');
             Route::get('/admin/purchases/{purchase}/setSuccess', 'Admin\PurchasesController@setSuccess');
             Route::get('/admin/purchases/{purchase}', 'Admin\PurchasesController@show');
+            if (config('admin.super_danger_zone')) {
+                Route::delete('/admin/purchases/{purchase}', 'Admin\PurchasesController@delete');
+            }
 
             /**
              * Credit System

--- a/src/app/Http/routes.php
+++ b/src/app/Http/routes.php
@@ -485,6 +485,12 @@ Route::group(['middleware' => ['installed']], function () {
                 '/admin/events/{event}/participants/{participant}/revoke',
                 'Admin\Events\ParticipantsController@revoke'
             );
+            if (config('admin.super_danger_zone')) {
+                Route::delete(
+                    '/admin/events/{event}/participants/{participant}',
+                    'Admin\Events\ParticipantsController@delete'
+                );
+            }
 
             /**
              * Announcements

--- a/src/app/Http/routes.php
+++ b/src/app/Http/routes.php
@@ -481,6 +481,10 @@ Route::group(['middleware' => ['installed']], function () {
                 '/admin/events/{event}/participants/{participant}/transfer',
                 'Admin\Events\ParticipantsController@transfer'
             );
+            Route::post(
+                '/admin/events/{event}/participants/{participant}/revoke',
+                'Admin\Events\ParticipantsController@revoke'
+            );
 
             /**
              * Announcements

--- a/src/app/User.php
+++ b/src/app/User.php
@@ -168,8 +168,11 @@ class User extends Authenticatable implements MustVerifyEmail
     /**
      * Get all Tickets for current user
      */
-    public function getAllTickets($eventId)    {
+    public function getAllTickets($eventId, $includeRevoked = false)    {
         $clauses = ['user_id' => $this->id, 'event_id' => $eventId];
+        if (!$includeRevoked) {
+            $clauses['revoked'] = 0;
+        }
         $eventParticipants = EventParticipant::where($clauses)->get();
         return $eventParticipants;
     }
@@ -199,7 +202,7 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function getTickets($eventId, $obj = false)
     {
-        $clauses = ['user_id' => $this->id, 'event_id' => $eventId];
+        $clauses = ['user_id' => $this->id, 'event_id' => $eventId, 'revoked' => 0];
         $eventParticipants = EventParticipant::where($clauses)->get();
         $return = array();
         foreach ($eventParticipants as $eventParticipant) {

--- a/src/config/admin.php
+++ b/src/config/admin.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'super_danger_zone' => env('I_KNOW_WHAT_I_AM_DOING_ENABLE_SUPER_DANGER_ZONE', false)
+];

--- a/src/database/migrations/2024_04_27_164045_add_participant_revoke.php
+++ b/src/database/migrations/2024_04_27_164045_add_participant_revoke.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('event_participants', function(Blueprint $table) {
+            $table->tinyInteger('revoked')->after('purchase_id')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('event_participants', function(Blueprint $table) {
+            $table->dropColumn('revoked');
+        });
+    }
+};

--- a/src/lang/de/tickets.php
+++ b/src/lang/de/tickets.php
@@ -20,6 +20,7 @@ return [
     /* Ticket Partial*/
     'has_been_gifted' => 'Dieses Ticket wurde verschenkt!',
     'not_eligable_for_seat' => 'Mit diesem Ticket kann kein Sitzplatz gebucht werden',
+    'has_been_revoked' => 'Dieses Ticket wurde zurückgerufen!',
     'gift_ticket' => 'Verschenke Ticket', 
     'gift_url' => 'Geschenk URL:',
     'revoke_gift' => 'Geschenk zurückziehen',

--- a/src/lang/en/tickets.php
+++ b/src/lang/en/tickets.php
@@ -20,6 +20,7 @@ return [
     /* Ticket Partial*/
     'has_been_gifted' => 'This Ticket has been gifted!',
     'not_eligable_for_seat' => 'This Ticket is not eligable for a seat',
+    'has_been_revoked' => 'This ticket has been revoked!',
     'gift_ticket' => 'Gift Ticket', 
     'gift_url' => 'Gift URL:',
     'revoke_gift' => 'Revoke Gift',

--- a/src/resources/assets/sass/admin.scss
+++ b/src/resources/assets/sass/admin.scss
@@ -8,6 +8,7 @@
 @import "node_modules/summernote/src/styles/lite/summernote-lite";
 @import "stylesheets/app/components/summernote_custom";
 @import "stylesheets/app/components/helper";
+@import "stylesheets/app/components/participants";
 @import "stylesheets/app/components/user-override";
 
 

--- a/src/resources/assets/sass/stylesheets/app/components/_participants.scss
+++ b/src/resources/assets/sass/stylesheets/app/components/_participants.scss
@@ -1,0 +1,11 @@
+/**
+ * Participants
+ */
+
+.participants-table {
+  tr {
+    &.revoked {
+      text-decoration: line-through;
+    }
+  }
+}

--- a/src/resources/views/admin/events/participants/index.blade.php
+++ b/src/resources/views/admin/events/participants/index.blade.php
@@ -53,7 +53,7 @@
 						</thead>
 						<tbody>
 							@foreach ($participants as $participant)
-							<tr @class(["odd", "gradeX", "revoked" => $participant->revoked])>
+							<tr @class(["odd", "gradeX", "table-danger revoked" => $participant->revoked])>
 								<td>
 									{{ $participant->user->username }}
 									@if ($participant->user->steamid)

--- a/src/resources/views/admin/events/participants/index.blade.php
+++ b/src/resources/views/admin/events/participants/index.blade.php
@@ -37,7 +37,7 @@
 			</div>
 			<div class="card-body">
 				<div class="dataTable_wrapper">
-					<table width="100%" class="table table-striped table-hover" id="seating_table">
+					<table width="100%" class="table table-striped table-hover participants-table" id="seating_table">
 						<thead>
 							<tr>
 								<th>User</th>
@@ -53,7 +53,7 @@
 						</thead>
 						<tbody>
 							@foreach ($participants as $participant)
-							<tr class="odd gradeX">
+							<tr @class(["odd", "gradeX", "revoked" => $participant->revoked])>
 								<td>
 									{{ $participant->user->username }}
 									@if ($participant->user->steamid)

--- a/src/resources/views/admin/events/participants/show.blade.php
+++ b/src/resources/views/admin/events/participants/show.blade.php
@@ -153,7 +153,7 @@
 		</div>
 
 		@if (!$participant->revoked)
-		<div class="card">
+		<div class="card mb-3">
 			<div class="card-header">Danger Zone</div>
 			<div class="card-body">
 			{{ Form::open([
@@ -162,6 +162,23 @@
 				]) }}
 				<div class="mb-3">
 					<button type="submit" class="btn btn-danger btn-block">Revoke</button>
+				</div>
+			{{ Form::close() }}
+			</div>
+		</div>
+		@endif
+
+		@if (config('admin.super_danger_zone') && $participant->revoked)
+		<div class="card mb-3">
+			<div class="card-header">Super Danger Zone</div>
+			<div class="card-body">
+			{{ Form::open([
+    				'url' => '/admin/events/' . $event->slug . '/participants/' . $participant->id,
+    				'onSubmit' => 'return ConfirmDelete()'
+				]) }}
+				{{ Form::hidden('_method', 'DELETE') }}
+				<div class="mb-3">
+					<button type="submit" class="btn btn-danger btn-block">Delete participant</button>
 				</div>
 			{{ Form::close() }}
 			</div>

--- a/src/resources/views/admin/events/participants/show.blade.php
+++ b/src/resources/views/admin/events/participants/show.blade.php
@@ -178,6 +178,10 @@
 				]) }}
 				{{ Form::hidden('_method', 'DELETE') }}
 				<div class="mb-3">
+					<div class="alert alert-danger">
+						This will remove the participant and related data, including clearing their seat. The underlying Purchase will not be removed.<br/>
+						This may have unintended side effects. Having a backup is highly recommended!
+					</div>
 					<button type="submit" class="btn btn-danger btn-block">Delete participant</button>
 				</div>
 			{{ Form::close() }}

--- a/src/resources/views/admin/events/participants/show.blade.php
+++ b/src/resources/views/admin/events/participants/show.blade.php
@@ -24,6 +24,10 @@
 
 @include ('layouts._partials._admin._event.dashMini')
 
+@if ($participant->revoked)
+	<div class="alert alert-danger">This participant has been revoked!</div>
+@endif
+
 <div class="row">
 	<div class="col-lg-8">
 
@@ -104,7 +108,11 @@
 						<p>{{ $participant->purchase->paypal_email }}</p>
 					@endif
 				@endif
-				@if ((!$participant->signed_in) && ((!$participant->ticket) || ($participant->purchase->status == "Success") ))
+				@if (
+        				(!$participant->revoked) &&
+        				(!$participant->signed_in) &&
+        				((!$participant->ticket) || ($participant->purchase->status == "Success"))
+					)
 					{{ Form::open(array('url'=>'/admin/events/' . $event->slug . '/participants/' . $participant->id . '/transfer')) }}
 						<div class="mb-3">
 							{{ Form::label('event_id','Transfer to event',array('id'=>'','class'=>'')) }}
@@ -144,7 +152,29 @@
 			</div>
 		</div>
 
+		@if (!$participant->revoked)
+		<div class="card">
+			<div class="card-header">Danger Zone</div>
+			<div class="card-body">
+			{{ Form::open([
+    				'url' => '/admin/events/' . $event->slug . '/participants/' . $participant->id . '/revoke',
+    				'onSubmit' => 'return ConfirmRevoke()'
+				]) }}
+				<div class="mb-3">
+					<button type="submit" class="btn btn-danger btn-block">Revoke</button>
+				</div>
+			{{ Form::close() }}
+			</div>
+		</div>
+		@endif
+
 	</div>
 </div>
+
+<script type="text/javascript">
+	function ConfirmRevoke() {
+		return confirm('Are you sure you want to revoke this participant?')
+	}
+</script>
 
 @endsection

--- a/src/resources/views/admin/events/participants/show.blade.php
+++ b/src/resources/views/admin/events/participants/show.blade.php
@@ -168,7 +168,7 @@
 		</div>
 		@endif
 
-		@if (config('admin.super_danger_zone') && $participant->revoked)
+		@if (config('admin.super_danger_zone'))
 		<div class="card mb-3">
 			<div class="card-header">Super Danger Zone</div>
 			<div class="card-body">

--- a/src/resources/views/admin/purchases/index.blade.php
+++ b/src/resources/views/admin/purchases/index.blade.php
@@ -79,6 +79,15 @@
 								}elseif($purchase->status == 'Danger') {
 									$statusColor = 'danger';
 								}
+                                $participantRevoked = false;
+                                if (!empty($purchase->participants)) {
+                                    foreach ($purchase->participants as $participant) {
+                                        if ($participant->revoked) {
+                                            $participantRevoked = true;
+                                            break;
+                                        }
+                                    }
+                                }
 							@endphp
 							<tr class="table-{{ $statusColor }} text-{{ $statusColor }}">
 								<td>{{ $purchase->id }}</td>
@@ -93,7 +102,12 @@
 									@endif
 								</td>
 								<td>@if(isset($purchase->user)) {{ $purchase->user->firstname }} {{ $purchase->user->surname }} @else User deleted @endif</td>
-								<td>{{ $purchase->status }}</td>
+								<td>
+									{{ $purchase->status }}
+									@if ($participantRevoked)
+										<span class="badge text-bg-warning">Participant(s) revoked</span>
+									@endif
+								</td>
 								<td>{{ $purchase->type }}</td>
 								<td>{{ $purchase->paypal_email }}</td>
 								<td>{{ $purchase->transaction_id }}</td>

--- a/src/resources/views/admin/purchases/show.blade.php
+++ b/src/resources/views/admin/purchases/show.blade.php
@@ -153,7 +153,7 @@
 				@if (count($purchase->participants) > 0)
 				<div class="mb-3">	
 					@foreach ($purchase->participants as $participant)
-						<a href="/admin/events/{{ $participant->event->slug }}/participants/{{ $participant->id }}"><button class="btn btn-block btn-success">View Participant - {{ $participant->user->username }}</button></a>
+						<a href="/admin/events/{{ $participant->event->slug }}/participants/{{ $participant->id }}"><button class="btn btn-block btn-{{ $participant->revoked ? 'warning' : 'success' }}">View Participant - {{ $participant->user->username }}{{ $participant->revoked ? ' (revoked)' : '' }}</button></a>
 					@endforeach
 				</div>
 				@endif

--- a/src/resources/views/admin/purchases/show.blade.php
+++ b/src/resources/views/admin/purchases/show.blade.php
@@ -161,6 +161,23 @@
 
 			</div>
 		</div>
+
+		@if (config('admin.super_danger_zone'))
+		<div class="card mb-3">
+			<div class="card-header">Super Danger Zone</div>
+			<div class="card-body">
+			{{ Form::open([
+    				'url' => '/admin/purchases/' . $purchase->id,
+    				'onSubmit' => 'return ConfirmDelete()'
+				]) }}
+				{{ Form::hidden('_method', 'DELETE') }}
+				<div class="mb-3">
+					<button type="submit" class="btn btn-danger btn-block">Delete purchase</button>
+				</div>
+				{{ Form::close() }}
+			</div>
+		</div>
+		@endif
 	</div>
 </div>
 

--- a/src/resources/views/admin/purchases/show.blade.php
+++ b/src/resources/views/admin/purchases/show.blade.php
@@ -156,7 +156,15 @@
 				@if (count($purchase->participants) > 0)
 				<div class="mb-3">	
 					@foreach ($purchase->participants as $participant)
-						<a href="/admin/events/{{ $participant->event->slug }}/participants/{{ $participant->id }}"><button class="btn btn-block btn-{{ $participant->revoked ? 'warning' : 'success' }}">View Participant - {{ $participant->user->username }}{{ $participant->revoked ? ' (revoked)' : '' }}</button></a>
+						<a href="/admin/events/{{ $participant->event->slug }}/participants/{{ $participant->id }}">
+							<button @class(["btn", "btn-block",
+											"btn-warning" => $participant->revoked,
+											"btn-success" => !$participant->revoked])>
+								View Participant - {{ $participant->user->username }}
+								@if ($participant->revoked)
+									(revoked)
+								@endif
+							</button></a>
 					@endforeach
 				</div>
 				@endif

--- a/src/resources/views/admin/purchases/show.blade.php
+++ b/src/resources/views/admin/purchases/show.blade.php
@@ -172,6 +172,7 @@
 				]) }}
 				{{ Form::hidden('_method', 'DELETE') }}
 				<div class="mb-3">
+					<div class="alert alert-danger">Deleting a purchase will also remove related data, like event participants. This has the potential to break stuff!<br/>Having a backup is highly recommended!</div>
 					<button type="submit" class="btn btn-danger btn-block">Delete purchase</button>
 				</div>
 				{{ Form::close() }}

--- a/src/resources/views/admin/purchases/show.blade.php
+++ b/src/resources/views/admin/purchases/show.blade.php
@@ -68,9 +68,12 @@
 							@endforeach
 						@elseif (!$purchase->participants->isEmpty())
 							@foreach ($purchase->participants as $participant)
-								<tr>
+								<tr @class(['table-warning' => $participant->revoked])>
 									<td>
 										{{ $participant->ticket->name }} for {{ $participant->event->display_name }}
+										@if ($participant->revoked)
+											<span class="badge text-bg-warning">Participant revoked</span>
+										@endif
 									</td>
 									<td>
 										1

--- a/src/resources/views/layouts/_partials/_tickets/index.blade.php
+++ b/src/resources/views/layouts/_partials/_tickets/index.blade.php
@@ -46,7 +46,7 @@
 			<span class="badge text-bg-info float-end" style="margin-top:2px;">@lang('tickets.not_eligable_for_seat')</span>
 		@endif
 		@if ($participant->revoked)
-			<span class="badge text-bg-danger float-end" style="margin-top: 2px;">revoked</span>
+			<span class="badge text-bg-danger float-end" style="margin-top: 2px;">@lang('tickets.has_been_revoked')</span>
 		@endif
 	</div>
 	<div class="card-body">

--- a/src/resources/views/layouts/_partials/_tickets/index.blade.php
+++ b/src/resources/views/layouts/_partials/_tickets/index.blade.php
@@ -1,5 +1,11 @@
 <div class="card mb-3">
-	<div class="card-header  bg-success-light text-success">
+	<div @class([
+			"card-header",
+			"bg-success-light" => !$participant->revoked,
+			"text-success" => !$participant->revoked,
+			"bg-danger-light" => $participant->revoked,
+			"text-danger" => $participant->revoked
+        ])>
 		@if ($participant->ticket)
 		<strong>{{ $participant->ticket->name }} 
 			@if ($participant->ticket && $participant->ticket->seatable) - @lang('events.seat'): 
@@ -38,6 +44,9 @@
 		@endif
 		@if ($participant->ticket && !$participant->ticket->seatable)
 			<span class="badge text-bg-info float-end" style="margin-top:2px;">@lang('tickets.not_eligable_for_seat')</span>
+		@endif
+		@if ($participant->revoked)
+			<span class="badge text-bg-danger float-end" style="margin-top: 2px;">revoked</span>
 		@endif
 	</div>
 	<div class="card-body">


### PR DESCRIPTION
This adds the ability to revoke `EventParticipants` by setting a flag on the model.

This also adds the ability to delete both an `EventParticipant` or a `Purchase`. These two features are locked behind an Environment variable to prevent the casual user from accidentally activating these features.

Partially addresses #541 