### PR TITLE
implement getEnvWithFallback helper

### DIFF
--- a/src/app/Libraries/Helpers.php
+++ b/src/app/Libraries/Helpers.php
@@ -26,8 +26,8 @@ use HaydenPierce\ClassFinder\ClassFinder;
 
 class Helpers
 {
-    
-    
+
+
     /**
      * Gets an array of all supported languages from the language directory.
      *
@@ -35,7 +35,7 @@ class Helpers
      */
     public static function getSupportedLocales()
     {
-        return array_map('basename', array_filter(glob(app()->langPath().'/*'), 'is_dir'));
+        return array_map('basename', array_filter(glob(app()->langPath() . '/*'), 'is_dir'));
     }
 
 
@@ -1028,5 +1028,18 @@ class Helpers
         })
             ->sortByDesc('win_count')
             ->take($count);
+    }
+
+    /**
+     * Get environment variable with fallback.
+     *
+     *  @param string $key
+     *  @param mixed $default
+     *  @return mixed
+     */
+    public static function getEnvWithFallback($key, $default = null)
+    {
+        $value = env($key);
+        return (is_null($value) || $value === '') ? $default : $value;
     }
 }

--- a/src/config/admin.php
+++ b/src/config/admin.php
@@ -1,5 +1,7 @@
 <?php
+
+use App\Libraries\Helpers;
 return [
-    'super_danger_zone' => env('I_KNOW_WHAT_I_AM_DOING_ENABLE_SUPER_DANGER_ZONE', false),
+    'super_danger_zone' => Helpers::getEnvWithFallback('I_KNOW_WHAT_I_AM_DOING_ENABLE_SUPER_DANGER_ZONE', false),
 
 ];

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -1,15 +1,17 @@
 <?php
+
+use App\Libraries\Helpers;
 return [
 
-    'env'               => env('APP_ENV', 'production'),
-    'debug'             => env('APP_DEBUG', false),
-    'url'               => env('APP_URL', 'localhost'),
+    'env'               => Helpers::getEnvWithFallback('APP_ENV', 'production'),
+    'debug'             => Helpers::getEnvWithFallback('APP_DEBUG', false),
+    'url'               => Helpers::getEnvWithFallback('APP_URL', 'localhost'),
     'timezone'          => 'UTC',
     'locale'            => 'en',
     'fallback_locale'   => 'en',
     'key'               => env('APP_KEY'),
     'cipher'            => 'AES-256-CBC',
-    'log'               => env('APP_LOG', 'errorlog'),
+    'log'               => Helpers::getEnvWithFallback('APP_LOG', 'errorlog'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/appearance.php
+++ b/src/config/appearance.php
@@ -1,7 +1,9 @@
 <?php
+
+use App\Libraries\Helpers;
 return [
 
-	'disable_custom_css_linking' => env('APPEAR_DISABLE_CUSTOM_CSS_LINKING', 'false'),
-	'disable_admin_appearance_css_settings' => env('APPEAR_DISABLE_ADMIN_APPEARANCE_CSS_SETTINGS', 'false'),
+	'disable_custom_css_linking' => Helpers::getEnvWithFallback('APPEAR_DISABLE_CUSTOM_CSS_LINKING', 'false'),
+	'disable_admin_appearance_css_settings' => Helpers::getEnvWithFallback('APPEAR_DISABLE_ADMIN_APPEARANCE_CSS_SETTINGS', 'false'),
 	
 ];

--- a/src/config/broadcasting.php
+++ b/src/config/broadcasting.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Libraries\Helpers;
+
 return [
 
     /*
@@ -13,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('BROADCAST_DRIVER', 'pusher'),
+    'default' => Helpers::getEnvWithFallback('BROADCAST_DRIVER', 'pusher'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/cache.php
+++ b/src/config/cache.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Libraries\Helpers;
+
 return [
 
     /*
@@ -13,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('CACHE_DRIVER', 'file'),
+    'default' => Helpers::getEnvWithFallback('CACHE_DRIVER', 'file'),
 
     /*
     |--------------------------------------------------------------------------
@@ -51,8 +53,8 @@ return [
             'driver'  => 'memcached',
             'servers' => [
                 [
-                    'host' => env('MEMCACHED_HOST', '127.0.0.1'),
-                    'port' => env('MEMCACHED_PORT', 11211),
+                    'host' => Helpers::getEnvWithFallback('MEMCACHED_HOST', '127.0.0.1'),
+                    'port' => Helpers::getEnvWithFallback('MEMCACHED_PORT', 11211),
                     'weight' => 100,
                 ],
             ],

--- a/src/config/database.php
+++ b/src/config/database.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Libraries\Helpers;
+
 return [
 
     /*
@@ -26,7 +28,7 @@ return [
     |
     */
 
-    'default' => env('DB_CONNECTION', 'mysql'),
+    'default' => Helpers::getEnvWithFallback('DB_CONNECTION', 'mysql'),
 
     /*
     |--------------------------------------------------------------------------
@@ -54,11 +56,11 @@ return [
 
         'mysql' => [
            'driver' => 'mysql',
-            'host' => env('DB_HOST', 'database'),
-            'port' => env('DB_PORT', '3306'),
-            'database' => env('DB_DATABASE', 'eventula_manager_database'),
-            'username' => env('DB_USERNAME', 'eventula_manager'),
-            'password' => env('DB_PASSWORD', 'password'),
+            'host' => Helpers::getEnvWithFallback('DB_HOST', 'database'),
+            'port' => Helpers::getEnvWithFallback('DB_PORT', '3306'),
+            'database' => Helpers::getEnvWithFallback('DB_DATABASE', 'eventula_manager_database'),
+            'username' => Helpers::getEnvWithFallback('DB_USERNAME', 'eventula_manager'),
+            'password' => Helpers::getEnvWithFallback('DB_PASSWORD', 'password'),
             'charset'   => 'utf8',
             'collation' => 'utf8_unicode_ci',
             'prefix'    => '',
@@ -68,10 +70,10 @@ return [
 
         'pgsql' => [
             'driver'   => 'pgsql',
-            'host'     => env('DB_HOST', 'localhost'),
-            'database' => env('DB_DATABASE', 'forge'),
-            'username' => env('DB_USERNAME', 'forge'),
-            'password' => env('DB_PASSWORD', ''),
+            'host'     => Helpers::getEnvWithFallback('DB_HOST', 'localhost'),
+            'database' => Helpers::getEnvWithFallback('DB_DATABASE', 'forge'),
+            'username' => Helpers::getEnvWithFallback('DB_USERNAME', 'forge'),
+            'password' => Helpers::getEnvWithFallback('DB_PASSWORD', ''),
             'charset'  => 'utf8',
             'prefix'   => '',
             'schema'   => 'public',
@@ -79,10 +81,10 @@ return [
 
         'sqlsrv' => [
             'driver'   => 'sqlsrv',
-            'host'     => env('DB_HOST', 'localhost'),
-            'database' => env('DB_DATABASE', 'forge'),
-            'username' => env('DB_USERNAME', 'forge'),
-            'password' => env('DB_PASSWORD', ''),
+            'host'     => Helpers::getEnvWithFallback('DB_HOST', 'localhost'),
+            'database' => Helpers::getEnvWithFallback('DB_DATABASE', 'forge'),
+            'username' => Helpers::getEnvWithFallback('DB_USERNAME', 'forge'),
+            'password' => Helpers::getEnvWithFallback('DB_PASSWORD', ''),
             'charset'  => 'utf8',
             'prefix'   => '',
         ],
@@ -118,9 +120,9 @@ return [
         'cluster' => false,
 
         'default' => [
-            'host'     => env('REDIS_HOST', 'localhost'),
-            'password' => env('REDIS_PASSWORD', null),
-            'port'     => env('REDIS_PORT', 6379),
+            'host'     => Helpers::getEnvWithFallback('REDIS_HOST', 'localhost'),
+            'password' => Helpers::getEnvWithFallback('REDIS_PASSWORD', null),
+            'port'     => Helpers::getEnvWithFallback('REDIS_PORT', 6379),
             'database' => 0,
         ],
 

--- a/src/config/eventula.php
+++ b/src/config/eventula.php
@@ -1,6 +1,8 @@
 <?php
+
+use App\Libraries\Helpers;
 return [
 
-	'url' => env('EVENTULA_URL', 'https://eventula.com'),
+	'url' => Helpers::getEnvWithFallback('EVENTULA_URL', 'https://eventula.com'),
 	
 ];

--- a/src/config/logging.php
+++ b/src/config/logging.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Libraries\Helpers;
+
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
 
@@ -16,7 +18,7 @@ return [
     |
     */
 
-    'default' => env('LOG_CHANNEL', 'errorlog'),
+    'default' => Helpers::getEnvWithFallback('LOG_CHANNEL', 'errorlog'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/mail.php
+++ b/src/config/mail.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Libraries\Helpers;
+
 return [
 
     /*
@@ -15,7 +17,7 @@ return [
     |
     */
 
-    'driver' => env('MAIL_DRIVER', 'mail'),
+    'driver' => Helpers::getEnvWithFallback('MAIL_DRIVER', 'mail'),
 
     /*
     |--------------------------------------------------------------------------
@@ -28,7 +30,7 @@ return [
     |
     */
 
-    'host' => env('MAIL_HOST', 'smtp.mailgun.org'),
+    'host' => Helpers::getEnvWithFallback('MAIL_HOST', 'smtp.mailgun.org'),
 
     /*
     |--------------------------------------------------------------------------
@@ -41,7 +43,7 @@ return [
     |
     */
 
-    'port' => env('MAIL_PORT', 587),
+    'port' => Helpers::getEnvWithFallback('MAIL_PORT', 587),
 
     /*
     |--------------------------------------------------------------------------
@@ -54,7 +56,7 @@ return [
     |
     */
 
-    'from' => ['address' => env('APP_EMAIL', 'no-reply@localhost'), 'name' => null],
+    'from' => ['address' => Helpers::getEnvWithFallback('APP_EMAIL', 'no-reply@localhost'), 'name' => null],
 
     /*
     |--------------------------------------------------------------------------
@@ -67,7 +69,7 @@ return [
     |
     */
 
-    'encryption' => env('MAIL_ENCRYPTION', 'tls'),
+    'encryption' => Helpers::getEnvWithFallback('MAIL_ENCRYPTION', 'tls'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/queue.php
+++ b/src/config/queue.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Libraries\Helpers;
+
 return [
 
     /*
@@ -16,7 +18,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'database'),
+    'default' => Helpers::getEnvWithFallback('QUEUE_CONNECTION', 'database'),
 
     /*
     |--------------------------------------------------------------------------
@@ -79,7 +81,7 @@ return [
     */
 
     'failed' => [
-        'database' => env('DB_CONNECTION', 'mysql'),
+        'database' => Helpers::getEnvWithFallback('DB_CONNECTION', 'mysql'),
         'table'    => 'failed_jobs',
     ],
 

--- a/src/config/session.php
+++ b/src/config/session.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Libraries\Helpers;
+
 use Illuminate\Support\Str;
 
 return [
@@ -128,7 +130,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
+        Str::slug(Helpers::getEnvWithFallback('APP_NAME', 'laravel'), '_').'_session'
     ),
 
     /*

--- a/src/database/migrations/2024_11_15_140752_remove_facebook_and_google_settings.php
+++ b/src/database/migrations/2024_11_15_140752_remove_facebook_and_google_settings.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Libraries\Helpers;
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 use App\ApiKey;
@@ -34,25 +36,25 @@ return new class extends Migration
         ApiKey::firstOrCreate(
             ['key' => 'facebook_pixel_id'],
             [
-                'value' => env('FACEBOOK_PIXEL_ID', null),
+                'value' => Helpers::getEnvWithFallback('FACEBOOK_PIXEL_ID', null),
             ]
         );
         ApiKey::firstOrCreate(
             ['key' => 'facebook_app_id'],
             [
-                'value' => env('FACEBOOK_APP_ID', null),
+                'value' => Helpers::getEnvWithFallback('FACEBOOK_APP_ID', null),
             ]
         );
         ApiKey::firstOrCreate(
             ['key' => 'facebook_app_secret'],
             [
-                'value' => env('FACEBOOK_APP_SECRET', null),
+                'value' => Helpers::getEnvWithFallback('FACEBOOK_APP_SECRET', null),
             ]
         );
         ApiKey::firstOrCreate(
             ['key'          => 'google_analytics_tracking_id'],
             [
-                'value'     => env('GOOGLE_ANALYTICS_TRACKING_ID', null),
+                'value'     => Helpers::getEnvWithFallback('GOOGLE_ANALYTICS_TRACKING_ID', null),
             ]
         );
         Setting::firstOrCreate(

--- a/src/database/seeders/ApiKeyTableSeeder.php
+++ b/src/database/seeders/ApiKeyTableSeeder.php
@@ -2,6 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Libraries\Helpers;
+
 use Illuminate\Database\Seeder;
 use App\ApiKey;
 
@@ -26,31 +28,31 @@ class ApiKeyTableSeeder extends Seeder
         ## Api Keys
         factory(ApiKey::class)->create([
             'key'          => 'paypal_username',
-            'value'         => env('PAYPAL_USERNAME', null),
+            'value'         => Helpers::getEnvWithFallback('PAYPAL_USERNAME', null),
         ]);
        factory(ApiKey::class)->create([
             'key'          => 'paypal_password',
-            'value'         => env('PAYPAL_PASSWORD', null),
+            'value'         => Helpers::getEnvWithFallback('PAYPAL_PASSWORD', null),
         ]);
         factory(ApiKey::class)->create([
             'key'          => 'paypal_signature',
-            'value'         => env('PAYPAL_SIGNATURE', null),
+            'value'         => Helpers::getEnvWithFallback('PAYPAL_SIGNATURE', null),
         ]);
         factory(ApiKey::class)->create([
             'key'          => 'stripe_public_key',
-            'value'         => env('STRIPE_PUBLIC_KEY', null),
+            'value'         => Helpers::getEnvWithFallback('STRIPE_PUBLIC_KEY', null),
         ]);
         factory(ApiKey::class)->create([
             'key'          => 'stripe_secret_key',
-            'value'         => env('STRIPE_SECRET_KEY', null),
+            'value'         => Helpers::getEnvWithFallback('STRIPE_SECRET_KEY', null),
         ]);
         factory(ApiKey::class)->create([
             'key'          => 'challonge_api_key',
-            'value'         => env('CHALLONGE_API_KEY', null),
+            'value'         => Helpers::getEnvWithFallback('CHALLONGE_API_KEY', null),
         ]);
         factory(ApiKey::class)->create([
             'key'          => 'steam_api_key',
-            'value'         => env('STEAM_API_KEY', null),
+            'value'         => Helpers::getEnvWithFallback('STEAM_API_KEY', null),
         ]);
     }
 }

--- a/src/database/seeders/RequiredDatabaseSeeder.php
+++ b/src/database/seeders/RequiredDatabaseSeeder.php
@@ -2,6 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Libraries\Helpers;
+
 use Illuminate\Database\Seeder;
 use App\Setting;
 use App\Appearance;
@@ -41,7 +43,7 @@ class RequiredDatabaseSeeder extends Seeder
         Setting::firstOrCreate(
             ['setting'          => 'org_name'],
             [
-                'value'         => env('APP_NAME', 'OrgNameHere'),
+                'value'         => Helpers::getEnvWithFallback('APP_NAME', 'OrgNameHere'),
                 'default'       => true,
                 'description'   => 'Name of the Organization'
             ]
@@ -49,7 +51,7 @@ class RequiredDatabaseSeeder extends Seeder
         Setting::firstOrCreate(
             ['setting'          => 'org_tagline'],
             [
-                'value'         => env('APP_TAGLINE', 'Tagline Here'),
+                'value'         => Helpers::getEnvWithFallback('APP_TAGLINE', 'Tagline Here'),
                 'default'       => true,
                 'description'   => 'Tagline of the Organization'
             ]
@@ -57,7 +59,7 @@ class RequiredDatabaseSeeder extends Seeder
         Setting::firstOrCreate(
             ['setting'          => 'seo_keywords'],
             [
-                'value'         => env('SEO_KEYWORDS', "Events,Eventula,Th0rn0"),
+                'value'         => Helpers::getEnvWithFallback('SEO_KEYWORDS', "Events,Eventula,Th0rn0"),
                 'default'       => true,
                 'description'   => 'Keywords for the Organization SEO'
             ]
@@ -65,7 +67,7 @@ class RequiredDatabaseSeeder extends Seeder
         Setting::firstOrCreate(
             ['setting'          => 'org_logo'],
             [
-                'value'         => env('APP_LOGO', '/storage/images/main/logo_main.png'),
+                'value'         => Helpers::getEnvWithFallback('APP_LOGO', '/storage/images/main/logo_main.png'),
                 'default'       => true,
                 'description'   => 'Organization Logo'
             ]
@@ -73,7 +75,7 @@ class RequiredDatabaseSeeder extends Seeder
         Setting::firstOrCreate(
             ['setting'          => 'org_favicon'],
             [
-                'value'         => env('APP_FAVICON', '/storage/images/main/favicon.ico'),
+                'value'         => Helpers::getEnvWithFallback('APP_FAVICON', '/storage/images/main/favicon.ico'),
                 'default'       => true,
                 'description'   => 'Organization Favicon'
             ]
@@ -586,47 +588,47 @@ class RequiredDatabaseSeeder extends Seeder
         ApiKey::firstOrCreate(
             ['key'          => 'paypal_username'],
             [
-                'value'         => env('PAYPAL_USERNAME', null),
+                'value'         => Helpers::getEnvWithFallback('PAYPAL_USERNAME', null),
             ]
         );
 
         ApiKey::firstOrCreate(
             ['key'          => 'paypal_password'],
             [
-                'value'         => env('PAYPAL_PASSWORD', null),
+                'value'         => Helpers::getEnvWithFallback('PAYPAL_PASSWORD', null),
             ]
         );
 
         ApiKey::firstOrCreate(
             ['key'          => 'paypal_signature'],
             [
-                'value'         => env('PAYPAL_SIGNATURE', null),
+                'value'         => Helpers::getEnvWithFallback('PAYPAL_SIGNATURE', null),
             ]
         );
 
         ApiKey::firstOrCreate(
             ['key'          => 'stripe_public_key'],
             [
-                'value'         => env('STRIPE_PUBLIC_KEY', null),
+                'value'         => Helpers::getEnvWithFallback('STRIPE_PUBLIC_KEY', null),
             ]
         );
 
         ApiKey::firstOrCreate(
             ['key'          => 'stripe_secret_key'],
             [
-                'value'         => env('STRIPE_SECRET_KEY', null),
+                'value'         => Helpers::getEnvWithFallback('STRIPE_SECRET_KEY', null),
             ]
         );
         ApiKey::firstOrCreate(
             ['key'          => 'challonge_api_key'],
             [
-                'value'         => env('CHALLONGE_API_KEY', null),
+                'value'         => Helpers::getEnvWithFallback('CHALLONGE_API_KEY', null),
             ]
             );
         ApiKey::firstOrCreate(
             ['key'          => 'steam_api_key'],
             [
-                'value'         => env('STEAM_API_KEY', null),
+                'value'         => Helpers::getEnvWithFallback('STEAM_API_KEY', null),
             ]
         );
 

--- a/src/database/seeders/SettingsTableSeeder.php
+++ b/src/database/seeders/SettingsTableSeeder.php
@@ -2,6 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Libraries\Helpers;
+
 use Illuminate\Database\Seeder;
 use App\Setting;
 use Faker\Factory as Faker;
@@ -25,7 +27,7 @@ class SettingsTableSeeder extends Seeder
         Setting::firstOrCreate(
             ['setting'          => 'org_name'],
             [
-                'value'         => env('APP_NAME', 'OrgNameHere'),
+                'value'         => Helpers::getEnvWithFallback('APP_NAME', 'OrgNameHere'),
                 'default'       => true,
                 'description'   => 'Name of the Organization'
             ]
@@ -33,7 +35,7 @@ class SettingsTableSeeder extends Seeder
         Setting::firstOrCreate(
             ['setting'          => 'org_tagline'],
             [
-                'value'         => env('APP_TAGLINE', 'Tagline Here'),
+                'value'         => Helpers::getEnvWithFallback('APP_TAGLINE', 'Tagline Here'),
                 'default'       => true,
                 'description'   => 'Tagline of the Organization'
             ]
@@ -41,7 +43,7 @@ class SettingsTableSeeder extends Seeder
         Setting::firstOrCreate(
             ['setting'          => 'seo_keywords'],
             [
-                'value'         => env('SEO_KEYWORDS', "Events,OrgNameHere,Tagline Here"),
+                'value'         => Helpers::getEnvWithFallback('SEO_KEYWORDS', "Events,OrgNameHere,Tagline Here"),
                 'default'       => true,
                 'description'   => 'Keywords for the Organization SEO'
             ]
@@ -49,7 +51,7 @@ class SettingsTableSeeder extends Seeder
         Setting::firstOrCreate(
             ['setting'          => 'org_logo'],
             [
-                'value'         => env('APP_LOGO', '/storage/images/main/logo_main.png'),
+                'value'         => Helpers::getEnvWithFallback('APP_LOGO', '/storage/images/main/logo_main.png'),
                 'default'       => true,
                 'description'   => 'Organization Logo'
             ]
@@ -57,7 +59,7 @@ class SettingsTableSeeder extends Seeder
         Setting::firstOrCreate(
             ['setting'          => 'org_favicon'],
             [
-                'value'         => env('APP_FAVICON', '/storage/images/main/favicon.ico'),
+                'value'         => Helpers::getEnvWithFallback('APP_FAVICON', '/storage/images/main/favicon.ico'),
                 'default'       => true,
                 'description'   => 'Organization Favicon'
             ]

--- a/src/database/seeders/TestCs2MatchMakingSeeder.php
+++ b/src/database/seeders/TestCs2MatchMakingSeeder.php
@@ -2,6 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Libraries\Helpers;
+
 use Illuminate\Database\Seeder;
 use Faker\Factory as Faker;
 use App\Game;
@@ -23,10 +25,10 @@ class TestCs2MatchMakingSeeder extends Seeder
      */
     public function run()
     {
-        $playeroneid = intval(env('playeroneid', 53));
-        $playertwoid = intval(env('playertwoid', 54));
-        $democount = intval(env('democount', 0));
-        $status = env('status', "WAITFORPLAYERS");
+        $playeroneid = intval(Helpers::getEnvWithFallback('playeroneid', 53));
+        $playertwoid = intval(Helpers::getEnvWithFallback('playertwoid', 54));
+        $democount = intval(Helpers::getEnvWithFallback('democount', 0));
+        $status = Helpers::getEnvWithFallback('status', "WAITFORPLAYERS");
 
         if ($playeroneid == $playertwoid) {
             throw new \Exception("player ids cannot be the same");

--- a/src/database/seeders/TestTournamentDemoSeeder.php
+++ b/src/database/seeders/TestTournamentDemoSeeder.php
@@ -2,6 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Libraries\Helpers;
+
 use Illuminate\Database\Seeder;
 use Faker\Factory as Faker;
 use App\Game;
@@ -23,8 +25,8 @@ class TestTournamentDemoSeeder extends Seeder
      */
     public function run()
     {
-        $challongematchid = intval(env('challongematchid', 0));
-        $democount = intval(env('democount', 0));
+        $challongematchid = intval(Helpers::getEnvWithFallback('challongematchid', 0));
+        $democount = intval(Helpers::getEnvWithFallback('democount', 0));
 
         if ($challongematchid == 0)
         {

--- a/src/resources/views/admin/index.blade.php
+++ b/src/resources/views/admin/index.blade.php
@@ -289,17 +289,17 @@
                 <div class="card-body">
                     <ul class="list-group">
                         <li class="list-group-item list-group-item-info"><strong>VERSION: <span
-                                    class="float-end">{{ env('VERSION', 'dev') }}</span></strong></li>
+                                    class="float-end">{{ Helpers::getEnvWithFallback('VERSION', 'dev') }}</span></strong></li>
                         <li class="list-group-item list-group-item-info"><strong>BUILDNUMBER: <span
-                                    class="float-end">{{ env('BUILDNUMBER', 'dev') }}</span></strong></li>
+                                    class="float-end">{{ Helpers::getEnvWithFallback('BUILDNUMBER', 'dev') }}</span></strong></li>
                         <li class="list-group-item list-group-item-info"><strong>BUILDID: <span
-                                    class="float-end">{{ env('BUILDID', 'dev') }}</span></strong></li>
+                                    class="float-end">{{ Helpers::getEnvWithFallback('BUILDID', 'dev') }}</span></strong></li>
                         <li class="list-group-item list-group-item-info"><strong>SOURCE_COMMIT: <span
-                                    class="float-end">{{ env('SOURCE_COMMIT', 'dev') }}</span></strong></li>
+                                    class="float-end">{{ Helpers::getEnvWithFallback('SOURCE_COMMIT', 'dev') }}</span></strong></li>
                         <li class="list-group-item list-group-item-info"><strong>SOURCE_REF: <span
-                                    class="float-end">{{ env('SOURCE_REF', 'dev') }}</span></strong></li>
+                                    class="float-end">{{ Helpers::getEnvWithFallback('SOURCE_REF', 'dev') }}</span></strong></li>
                         <li class="list-group-item list-group-item-info"><strong>BUILDNODE: <span
-                                    class="float-end">{{ env('BUILDNODE', 'dev') }}</span></strong></li>
+                                    class="float-end">{{ Helpers::getEnvWithFallback('BUILDNODE', 'dev') }}</span></strong></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Due to changed behaviour of the env() function at some point in time, an empty string in an env variable now does not lead to using the default anymore.

This PR implements a small helper function to do this and replaces any call to env($1,$2) with a call to that helper.
I have tested locally as good as possible.