### PR TITLE
fix(events): correct property name for `tickettype_hide_policy` with …

### DIFF
--- a/src/app/Http/Controllers/Admin/Events/EventsController.php
+++ b/src/app/Http/Controllers/Admin/Events/EventsController.php
@@ -99,7 +99,7 @@ class EventsController extends Controller
         $event->matchmaking_enabled         = (bool)$request->matchmaking_enabled;
         $event->tournaments_freebies        = (bool)$request->tournaments_freebies;
         $event->tournaments_staff           = (bool)$request->tournaments_staff;
-        $event->tickettype_hide_policy      = $request->ticket_hide_policy ?? -1;
+        $event->tickettype_hide_policy      = (int)($request->ticket_hide_policy ?? -1);
         if (!$event->save()) {
             Session::flash('alert-danger', 'Cannot Save Event!');
             return Redirect::to('admin/events/' . $event->slug);


### PR DESCRIPTION
fix(events): correct property name for `tickettype_hide_policy` with fallback value

- Updated `EventsController` to correctly handle the `tickettype_hide_policy` property with a default fallback when absent.


closes #1583
